### PR TITLE
fix path in tracking beacon

### DIFF
--- a/CountryStateSelector/README.md
+++ b/CountryStateSelector/README.md
@@ -19,4 +19,4 @@ Country and state selector source code is in following repository: https://githu
 
 If you want to adjust the implementation, first download [Kentico Cloud Custom Elements Devkit](https://github.com/kentico/custom-element-devkit). Source code of this selector needs be positioned within `/client/custom-elements` folder. For further instructions on devkit implementation, please refer to [Custom Element Devkit README](https://github.com/Kentico/custom-element-devkit/blob/master/readme.md).
 
-![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-elements-samples/CountryStateSelector?pixel)
+![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-element-samples/CountryStateSelector?pixel)

--- a/Geolocation-Leaflet/README.md
+++ b/Geolocation-Leaflet/README.md
@@ -25,4 +25,4 @@ You can specify other {JSON} parameters as a part of the configuration to set th
     "zoom": 10
 }
 ```
-![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-elements-samples/Geolocation-Leaflet?pixel)
+![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-element-samples/Geolocation-Leaflet?pixel)

--- a/Magento/README.md
+++ b/Magento/README.md
@@ -31,4 +31,4 @@ Magento product selector source code is in following repository: https://github.
 
 If you want to adjust the implementation, first download [Kentico Cloud Custom Elements Devkit](https://github.com/kentico/custom-element-devkit). Source code of this selector needs be positioned within `/client/custom-elements` folder. For further instructions on devkit implementation, please refer to [Custom Element Devkit README](https://github.com/Kentico/custom-element-devkit/blob/master/readme.md).
 
-![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-elements-samples/Magento?pixel)
+![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-element-samples/Magento?pixel)

--- a/Optimizely/README.md
+++ b/Optimizely/README.md
@@ -27,4 +27,4 @@ Optimizely audiences selector source code is in following repository: https://gi
 
 If you want to adjust the implementation, first download [Kentico Cloud Custom Elements Devkit](https://github.com/kentico/custom-element-devkit). Source code of this selector needs be positioned within `/client/custom-elements` folder. For further instructions on devkit implementation, please refer to [Custom Element Devkit README](https://github.com/Kentico/custom-element-devkit/blob/master/readme.md).
 
-![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-elements-samples/Optimizely?pixel)
+![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-element-samples/Optimizely?pixel)

--- a/Shopify/README.md
+++ b/Shopify/README.md
@@ -27,4 +27,4 @@ Shopify product selector source code is in following repository: https://github.
 
 If you want to adjust the implementation, first download [Kentico Cloud Custom Elements Devkit](https://github.com/kentico/custom-element-devkit). Source code of this selector needs be positioned within `/client/custom-elements` folder. For further instructions on devkit implementation, please refer to [Custom Element Devkit README](https://github.com/Kentico/custom-element-devkit/blob/master/readme.md).
 
-![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-elements-samples/Shopify?pixel)
+![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-element-samples/Shopify?pixel)

--- a/Switch/README.md
+++ b/Switch/README.md
@@ -30,4 +30,4 @@ You can specify the Parameters {JSON} part of the configuration to configure the
     "label": "Accepted"
 }
 ```
-![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-elements-samples/Switch?pixel)
+![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-element-samples/Switch?pixel)

--- a/SyntaxHighlighter/README.md
+++ b/SyntaxHighlighter/README.md
@@ -46,3 +46,5 @@ Syntax Highlighter source code is in the following repository: https://github.co
 
 Syntax Highlighter is released under the MIT license.
 The Ace source code that Syntax Highlighter uses is released under the BSD license.
+
+![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-element-samples/SyntaxHighlighter?pixel)

--- a/WYSIWYG-Quill/README.md
+++ b/WYSIWYG-Quill/README.md
@@ -13,4 +13,4 @@ For RTL support specify the Parameters {JSON} part of the configuration with:
     "rtl": true
 }
 ```
-![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-elements-samples/WYSIWYG-Quill?pixel)
+![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-element-samples/WYSIWYG-Quill?pixel)

--- a/YoutubeVideoPreview/README.md
+++ b/YoutubeVideoPreview/README.md
@@ -18,4 +18,4 @@ Possible configurations:
 
 ![screenshot](https://amend.cz/youtube/youtube1.png)
 
-![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-elements-samples/YoutubeVideoPreview?pixel)
+![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/custom-element-samples/YoutubeVideoPreview?pixel)


### PR DESCRIPTION
### Motivation

We had incorrectly set the analytics beacon path. It contained `custom-elements-samples` instead of `custom-element-sample` (element in singular form).

I have add the tracking beacon to the Syntex Highlighter.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [x] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Check if the tracking paths are correct.
