### PR TITLE
Implement basic request repeater.

### DIFF
--- a/RequestRepeater/index.js
+++ b/RequestRepeater/index.js
@@ -1,0 +1,111 @@
+const https = require('https');
+const querystring = require('querystring');
+
+/* ========Config Section======== */
+const host = process.env.HOST;
+const path = process.env.PATH;
+const accessControlAllowOriginValue = process.env.ACCESS_CONTROL_ALLOW_ORIGIN;
+const accessControlAllowHeadersValue = process.env.ACCESS_CONTROL_ALLOW_HEADERS;
+
+// Bearer token authentization
+const bearerToken = process.env.BEARER_TOKEN;
+
+//  Basic authentication credentials   
+const username = process.env.USERNAME;
+const password = process.env.PASSWORD;
+/* ========Config Section======== */
+
+let authorizationHeaderValue;
+
+if (bearerToken || (username && password)) {
+    authorizationHeaderValue = bearerToken ?
+        `Bearer ${bearerToken}` :
+        `Basic ${new Buffer(username + ":" + password).toString('base64')}`;
+}
+
+let requestOptions = {
+    host: host,
+    path: path,
+    port: 443,
+    method: 'GET',
+};
+
+const request = (queryStringParameters, headers) => {
+
+    if (queryStringParameters) {
+        requestOptions.path = `${requestOptions.path}?${querystring.stringify(queryStringParameters)}`;
+    }
+
+    if (authorizationHeaderValue) {
+        headers['Authorization'] = authorizationHeaderValue;
+    }
+
+    headers['Host'] = host;
+    requestOptions.headers = headers;
+
+    return new Promise((resolve, reject) => {
+        https.request(requestOptions, response => {
+            let data = '';
+            response.on('data', chunk => {
+                data += chunk;
+            });
+            response.on('end', () => {
+                const dataObject = JSON.parse(data);
+                response.data = dataObject;
+                resolve(response);
+            });
+        })
+            .on('error', error => {
+                reject(error);
+            })
+            .end();
+    });
+};
+
+exports.handler = (event, context, callback) => {
+
+    const corsHeaders = {
+        'Access-Control-Allow-Origin': accessControlAllowOriginValue,
+        'Access-Control-Allow-Headers': accessControlAllowHeadersValue
+    };
+
+    const repeatResponse = (response) => {
+        let multiValueHeaders = {};
+
+        for (const headerName in response.headers) {
+            if (Array.isArray(response.headers[headerName])) {
+                multiValueHeaders[headerName] = response.headers[headerName];
+                delete response.headers[headerName];
+            }
+        }
+
+        callback(null, {
+            statusCode: response.statusCode,
+            body: JSON.stringify(response.data),
+            headers: { ...response.headers, ...corsHeaders },
+            multiValueHeaders: multiValueHeaders,
+        });
+    };
+
+    const sendError = (error) => {
+        callback(null, {
+            statusCode: '400',
+            body: JSON.stringify(error),
+            headers: corsHeaders,
+        });
+    };
+
+    switch (event.httpMethod) {
+        case 'GET':
+            request(event.queryStringParameters, event.headers)
+                .then((response) => {
+                    repeatResponse(response);
+                })
+                .catch(error => {
+                    sendError(error);
+                });
+            break;
+        default:
+            sendError(new Error(`Unsupported method "${event.httpMethod}"`));
+    }
+};

--- a/RequestRepeater/readme.md
+++ b/RequestRepeater/readme.md
@@ -1,0 +1,29 @@
+# Request repeater
+RequestRepeater is simple AWS Lambda node.js script which repeats GET request (copies querystring and headers) and adds authorization header. This utility bypasses browsers' CORS policy as well as provide a safe place for storing sensitive data such as credentials or tokens. 
+
+# Usage
+
+Copy and paste script into [ASW Lambda](https://docs.aws.amazon.com/lambda/latest/dg/programming-model.html) (node.js) and configure environment variables (or edit config section in script directly).
+
+Configuration:
+
+```
+HOST - host of the requested service
+PATH - uri path
+ACCESS_CONTROL_ALLOW_ORIGIN - Access-Control-Allow-Origin value
+ACCESS_CONTROL_ALLOW_HEADERS - Access-Control-Allow-Headers value
+BEARER_TOKEN - security token
+USERNAME - username for basic authentization
+PASSWORD - password for basic authentization
+```
+
+Example environment variable key-value pair (without quotation marks):
+```
+"HOST" : "google.com"
+"PATH" : "/index.php/rest/V1/products"
+"ACCESS_CONTROL_ALLOW_ORIGIN" : "*"
+"ACCESS_CONTROL_ALLOW_HEADERS" : "*"
+"BEARER_TOKEN" : "xqxqoxop5jf5jrzbpxz9o4vqvt47akuou"
+"USERNAME" : "makma"
+"PASSWORD" : "easterEgg"
+```


### PR DESCRIPTION
### Motivation

RequestRepeater is simple AWS Lambda node.js script which repeats GET request (copies querystring) and adds authorization header. This utility bypasses browsers' CORS policy as well as provide a safe place for storing sensitive data such as credentials or tokens.

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [X] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Copy `n paste into aws lambda, configure and try!
